### PR TITLE
Support Docker image building and pushing via GitHub actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,56 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: ["main"]
+    tags:
+      - "v*"
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get current branch or tag
+        id: get_ref
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            REF_NAME="${{ github.event.pull_request.head.ref }}"
+          else
+            REF_NAME=$(echo ${GITHUB_REF#refs/*/})
+          fi
+          echo "REF_NAME=$REF_NAME" >> $GITHUB_ENV
+          echo "Current ref is: $REF_NAME"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: us-docker.pkg.dev/qpoint-edge/public/kubernetes-qtap-operator
+          tags: |
+            type=sha
+            type=raw,value=branch-${{ env.REF_NAME }},enable=${{ env.REF_NAME != 'main' }}
+            type=raw,value=release-${{ env.REF_NAME }},enable=${{ startsWith(env.REF_NAME, 'v') }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GAR
+        uses: docker/login-action@v3
+        with:
+          registry: us-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GAR_JSON_KEY }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+tag=sha-$(git rev-parse --verify HEAD --short)
+
+# build image
+docker build \
+  -t us-docker.pkg.dev/qpoint-edge/public/kubernetes-qtap-operator:"${tag}" \
+  .

--- a/scripts/push
+++ b/scripts/push
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -eu
+
+tag=sha-$(git rev-parse --verify HEAD --short)
+
+# push
+docker push us-docker.pkg.dev/qpoint-edge/public/kubernetes-qtap-operator:"${tag}"


### PR DESCRIPTION
This pull request ads support for building Docker images and pushing to `us-docker.pkg.dev/qpoint-edge/public/kubernetes-qtap-operator`.