### PR TITLE
Add Helmify generation for a Helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Dockerfile.cross
 
 # temp files
 tmp/
+
+# Helmify
+chart/

--- a/Makefile
+++ b/Makefile
@@ -235,3 +235,13 @@ $(ENVTEST): $(LOCALBIN)
 air: $(AIR) ## Download air locally if necessary.
 $(AIR): $(LOCALBIN)
 	test -s $(LOCALBIN)/air || GOBIN=$(LOCALBIN) go install github.com/cosmtrek/air@latest
+
+HELMIFY ?= $(LOCALBIN)/helmify
+
+.PHONY: helmify
+helmify: $(HELMIFY) ## Download helmify locally if necessary.
+$(HELMIFY): $(LOCALBIN)
+	test -s $(LOCALBIN)/helmify || GOBIN=$(LOCALBIN) go install github.com/arttor/helmify/cmd/helmify@latest
+
+helm: manifests kustomize helmify
+	$(KUSTOMIZE) build config/default | $(HELMIFY)


### PR DESCRIPTION
This uses https://github.com/arttor/helmify and specifically the setup for Kubebuilder: https://github.com/arttor/helmify#integrate-to-your-operator-sdkkubebuilder-project. This will produce a chart that needs some post processing before being pushed to https://github.com/qpoint-io/helm-charts.