### PR TITLE
Use the semvar tag for the egress-init-tag

### DIFF
--- a/config/webhook/configmap.yaml
+++ b/config/webhook/configmap.yaml
@@ -6,5 +6,5 @@ metadata:
 data:
   annotations.yaml: |
     qpoint.io/inject-ca: "true"
-    qpoint.io/egress-init-tag: "release-v0.0.2"
+    qpoint.io/egress-init-tag: "0.0.5"
     qpoint.io/egress-to-domain: "qtap-gateway.qpoint.svc.cluster.local"


### PR DESCRIPTION
This uses https://github.com/qpoint-io/kubernetes-qtap-init/releases/tag/v0.0.5 which is tagged correctly from https://github.com/qpoint-io/kubernetes-qtap-init/pull/8.