### PR TITLE
Allow the init container to run as root

### DIFF
--- a/api/v1/egress.go
+++ b/api/v1/egress.go
@@ -8,6 +8,12 @@ import (
 
 const INIT_IMAGE = "us-docker.pkg.dev/qpoint-edge/public/kubernetes-qtap-init"
 
+var (
+	RUN_AS_USER     int64 = 0     // The root user
+	RUN_AS_GROUP    int64 = 0     // The root group
+	RUN_AS_NON_ROOT       = false // Allow running as root
+)
+
 func MutateEgress(pod *corev1.Pod, config *Config) error {
 	// fetch the init image tag
 	tag := config.Get("egress-init-tag")
@@ -21,6 +27,11 @@ func MutateEgress(pod *corev1.Pod, config *Config) error {
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{"NET_ADMIN"},
 			},
+			// The init container needs to run as root as it modifies the network
+			// for the pod
+			RunAsUser:    &RUN_AS_USER,
+			RunAsGroup:   &RUN_AS_GROUP,
+			RunAsNonRoot: &RUN_AS_NON_ROOT,
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3
 	sigs.k8s.io/controller-runtime v0.16.3
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -64,5 +65,4 @@ require (
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )


### PR DESCRIPTION
The init container (https://github.com/qpoint-io/kubernetes-qtap-init) needs to run as root as it modifies the `iptables` rules for a pod and persists them. This container needs to run with elevated permissions which already require the `NET_ADMIN` capability but it also needs to run as the root user. Under some circumstances some pod specs have the `securityContext` set to prevent running as root.

Container-level `securityContext` settings override pod-level `securityContext` settings in Kubernetes. This means that if a setting is defined at both the pod and container levels, the container-level setting takes precedence for that specific container.

For example, if you specify a runAsUser at the pod level and a different runAsUser at the container level, the container will use the runAsUser value specified in its own `securityContext`, not the one from the pod's `securityContext`.

The init container has unique security requirements and this pull request ensures that those requirements are met for the container.

This pull request replaces https://github.com/qpoint-io/kubernetes-qtap-operator/pull/11.