### PR TITLE
Adjust the priority for egress enablement. First check namespace label then pod annotation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
 # qtap-operator
+
 A kubernetes operator to simplify routing outbound traffic through Qpoint's 3rd-party API Gateway
 
 ## Install
 
 Helm
 
-```
-todo
+```text
+helm install qtap-operator qpoint/qtap-operator --namespace qpoint
 ```
 
 Manual
 
-```
-todo
-```
+
+The pre-built Docker container can be found at us-docker.pkg.dev/qpoint-edge/public/kubernetes-qtap-operator and uses the tag for the release <https://github.com/qpoint-io/kubernetes-qtap-operator/releases>. See <https://github.com/qpoint-io/helm-charts/blob/main/charts/qtap-operator/templates/deployment.yaml> for an example of a Deployment.
 
 ## Configure Egress
 
 __Option 1:__ Namespace label
 
-```
+```text
 kubectl label namespace <namespace> qpoint-egress=enabled
 ```
 
 __Option 2:__ Pod annotation
 
-```
+```text
 apiVersion: v1
 kind: Pod
 metadata:
@@ -34,11 +34,26 @@ metadata:
     qpoint.io/egress: enabled
 ```
 
+The order of precedence is that a pod annotation can override a namespace label. For example the following would enable for a namespace but disable for a pod.
+
+```text
+kubectl label namespace <namespace> qpoint-egress=enabled
+```
+
+```text
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello-world
+  annotations:
+    qpoint.io/egress: disabled
+```
+
 ## Local Dev
 
 Bootstrap dev cluster (uses KinD) with live-reloading
 
-```
+```text
 make dev
 ```
 


### PR DESCRIPTION
It is possible that the pod label `qpoint-egress=enabled` is set yet it needs to be disabled for a pod. Examples of this need can be seen for situations like https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/troubleshooting/issues-with-istio/. This pull request makes it so that the namespace check is first and then pod check is done second and can override the namespace setting.