### PR TITLE
Introduce sidecar injection for the gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ helm install qtap-operator qpoint/qtap-operator --namespace qpoint
 
 Manual
 
-
 The pre-built Docker container can be found at us-docker.pkg.dev/qpoint-edge/public/kubernetes-qtap-operator and uses the tag for the release <https://github.com/qpoint-io/kubernetes-qtap-operator/releases>. See <https://github.com/qpoint-io/helm-charts/blob/main/charts/qtap-operator/templates/deployment.yaml> for an example of a Deployment.
 
 ## Configure Egress

--- a/api/v1/egress.go
+++ b/api/v1/egress.go
@@ -4,19 +4,21 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const INIT_IMAGE = "us-docker.pkg.dev/qpoint-edge/public/kubernetes-qtap-init"
+const QTAP_IMAGE = "us-docker.pkg.dev/qpoint-edge/public/qtap"
 
 var (
-	RUN_AS_USER     int64 = 0     // The root user
-	RUN_AS_GROUP    int64 = 0     // The root group
-	RUN_AS_NON_ROOT       = false // Allow running as root
+	ROOT_USER       int64 = 0 // The root user
+	ROOT_GROUP      int64 = 0 // The root group
+	RUN_AS_NON_ROOT       = false
 )
 
 func MutateEgress(pod *corev1.Pod, config *Config) error {
 	// fetch the init image tag
-	tag := config.Get("egress-init-tag")
+	tag := config.GetAnnotation("egress-init-tag")
 
 	// create an init container
 	initContainer := corev1.Container{
@@ -29,15 +31,14 @@ func MutateEgress(pod *corev1.Pod, config *Config) error {
 			},
 			// The init container needs to run as root as it modifies the network
 			// for the pod
-			RunAsUser:    &RUN_AS_USER,
-			RunAsGroup:   &RUN_AS_GROUP,
-			RunAsNonRoot: &RUN_AS_NON_ROOT,
+			RunAsUser:    &ROOT_USER,
+			RunAsGroup:   &ROOT_GROUP,
+			RunAsNonRoot: &RUN_AS_NON_ROOT, // Allow running as root
 		},
 	}
 
 	// TO_ADDR
-	toAddr := config.Get("egress-to-addr")
-	if toAddr != "" {
+	if toAddr := config.GetAnnotation("egress-to-addr"); toAddr != "" {
 		initContainer.Env = append(initContainer.Env, corev1.EnvVar{
 			Name:  "TO_ADDR",
 			Value: toAddr,
@@ -45,8 +46,7 @@ func MutateEgress(pod *corev1.Pod, config *Config) error {
 	}
 
 	// TO_DOMAIN
-	toDomain := config.Get("egress-to-domain")
-	if toAddr == "" && toDomain != "" {
+	if toDomain := config.GetAnnotation("egress-to-domain"); toDomain != "" {
 		initContainer.Env = append(initContainer.Env, corev1.EnvVar{
 			Name:  "TO_DOMAIN",
 			Value: toDomain,
@@ -54,8 +54,7 @@ func MutateEgress(pod *corev1.Pod, config *Config) error {
 	}
 
 	// PORT_MAPPING
-	portMapping := config.Get("egress-port-mapping")
-	if portMapping != "" {
+	if portMapping := config.GetAnnotation("egress-port-mapping"); portMapping != "" {
 		initContainer.Env = append(initContainer.Env, corev1.EnvVar{
 			Name:  "PORT_MAPPING",
 			Value: portMapping,
@@ -63,8 +62,7 @@ func MutateEgress(pod *corev1.Pod, config *Config) error {
 	}
 
 	// ACCEPT_UIDS
-	acceptUids := config.Get("egress-accept-uids")
-	if acceptUids != "" {
+	if acceptUids := config.GetAnnotation("egress-accept-uids"); acceptUids != "" {
 		initContainer.Env = append(initContainer.Env, corev1.EnvVar{
 			Name:  "ACCEPT_UIDS",
 			Value: acceptUids,
@@ -72,8 +70,7 @@ func MutateEgress(pod *corev1.Pod, config *Config) error {
 	}
 
 	// ACCEPT_GIDS
-	acceptGids := config.Get("egress-accept-gids")
-	if acceptGids != "" {
+	if acceptGids := config.GetAnnotation("egress-accept-gids"); acceptGids != "" {
 		initContainer.Env = append(initContainer.Env, corev1.EnvVar{
 			Name:  "ACCEPT_GIDS",
 			Value: acceptGids,
@@ -87,6 +84,142 @@ func MutateEgress(pod *corev1.Pod, config *Config) error {
 
 	// append to the list
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
+
+	// gtg
+	return nil
+}
+
+func MutateInjection(pod *corev1.Pod, config *Config) error {
+	// fetch the init image tag
+	tag := config.GetAnnotation("qtap-tag")
+
+	// create an init container
+	qtapContainer := corev1.Container{
+		Name:  "qtap",
+		Image: fmt.Sprintf("%s:%s", QTAP_IMAGE, tag),
+		Args:  []string{"gateway"},
+		Env:   []corev1.EnvVar{},
+		StartupProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.IntOrString{
+						IntVal: 8080,
+					},
+				},
+			},
+			InitialDelaySeconds: 3,
+			PeriodSeconds:       5,
+			TimeoutSeconds:      2,
+			SuccessThreshold:    1,
+			FailureThreshold:    20,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.IntOrString{
+						IntVal: 8080,
+					},
+				},
+			},
+			InitialDelaySeconds: 3,
+			PeriodSeconds:       5,
+			TimeoutSeconds:      2,
+			SuccessThreshold:    1,
+			FailureThreshold:    1,
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{
+						IntVal: 8080,
+					},
+				},
+			},
+			InitialDelaySeconds: 3,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      2,
+			SuccessThreshold:    1,
+			FailureThreshold:    3,
+		},
+	}
+
+	// LOG_LEVEL
+	if logLevel := config.GetAnnotation("log-level"); logLevel != "" {
+		qtapContainer.Env = append(qtapContainer.Env, corev1.EnvVar{
+			Name:  "LOG_LEVEL",
+			Value: logLevel,
+		})
+	}
+
+	// LOG_ENCODING
+	if logEncoding := config.GetAnnotation("log-encoding"); logEncoding != "" {
+		qtapContainer.Env = append(qtapContainer.Env, corev1.EnvVar{
+			Name:  "LOG_ENCODING",
+			Value: logEncoding,
+		})
+	}
+
+	// LOG_CALLER
+	if logCaller := config.GetAnnotation("log-caller"); logCaller != "" {
+		qtapContainer.Env = append(qtapContainer.Env, corev1.EnvVar{
+			Name:  "LOG_CALLER",
+			Value: logCaller,
+		})
+	}
+
+	// HTTP_LISTEN
+	if httpListen := config.GetAnnotation("https-listen"); httpListen != "" {
+		qtapContainer.Env = append(qtapContainer.Env, corev1.EnvVar{
+			Name:  "HTTP_LISTEN",
+			Value: httpListen,
+		})
+	}
+
+	// HTTPS_LISTEN
+	if httpsListen := config.GetAnnotation("https-listen"); httpsListen != "" {
+		qtapContainer.Env = append(qtapContainer.Env, corev1.EnvVar{
+			Name:  "HTTPS_LISTEN",
+			Value: httpsListen,
+		})
+	}
+
+	// TCP_LISTEN
+	if tcpListen := config.GetAnnotation("tcp-listen"); tcpListen != "" {
+		qtapContainer.Env = append(qtapContainer.Env, corev1.EnvVar{
+			Name:  "TCP_LISTEN",
+			Value: tcpListen,
+		})
+	}
+
+	// BLOCK_UNKNOWN
+	if blockUnknown := config.GetAnnotation("block-unknown"); blockUnknown != "" {
+		qtapContainer.Env = append(qtapContainer.Env, corev1.EnvVar{
+			Name:  "BLOCK_UNKNOWN",
+			Value: blockUnknown,
+		})
+	}
+
+	// ENVOY_LOG_LEVEL
+	if envoyLogLevel := config.GetAnnotation("envoy-log-level"); envoyLogLevel != "" {
+		qtapContainer.Env = append(qtapContainer.Env, corev1.EnvVar{
+			Name:  "ENVOY_LOG_LEVEL",
+			Value: envoyLogLevel,
+		})
+	}
+
+	// DNS_LOOKUP_FAMILY
+	if dnsLookupFamily := config.GetAnnotation("dns-lookup-family"); dnsLookupFamily != "" {
+		qtapContainer.Env = append(qtapContainer.Env, corev1.EnvVar{
+			Name:  "DNS_LOOKUP_FAMILY",
+			Value: dnsLookupFamily,
+		})
+	}
+
+	// append to the list
+	pod.Spec.Containers = append(pod.Spec.Containers, qtapContainer)
 
 	// gtg
 	return nil

--- a/api/v1/egress.go
+++ b/api/v1/egress.go
@@ -191,7 +191,7 @@ func MutateInjection(pod *corev1.Pod, config *Config) error {
 	}
 
 	// HTTP_LISTEN
-	if httpListen := config.GetAnnotation("https-listen"); httpListen != "" {
+	if httpListen := config.GetAnnotation("http-listen"); httpListen != "" {
 		qtapContainer.Env = append(qtapContainer.Env, corev1.EnvVar{
 			Name:  "HTTP_LISTEN",
 			Value: httpListen,

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,9 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "list", "watch", "create"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/created-by: qtap-operator
     app.kubernetes.io/part-of: qtap-operator
     app.kubernetes.io/managed-by: kustomize
-  name: manager-role
+  name: manager-cluster-role
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -16,6 +16,25 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "list", "watch"]
-- apiGroups: [""] 
+- apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "list", "watch", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: manager-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: qtap-operator
+    app.kubernetes.io/part-of: qtap-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: manager-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch"]

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,10 +8,30 @@ metadata:
     app.kubernetes.io/created-by: qtap-operator
     app.kubernetes.io/part-of: qtap-operator
     app.kubernetes.io/managed-by: kustomize
-  name: manager-rolebinding
+  name: manager-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  name: manager-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: qtap-operator
+    app.kubernetes.io/part-of: qtap-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
   name: manager-role
 subjects:
 - kind: ServiceAccount

--- a/config/webhook/configmap.yaml
+++ b/config/webhook/configmap.yaml
@@ -6,5 +6,6 @@ metadata:
 data:
   annotations.yaml: |
     qpoint.io/inject-ca: "true"
-    qpoint.io/egress-init-tag: "0.0.5"
+    qpoint.io/egress-init-tag: "v0.0.7"
     qpoint.io/egress-to-domain: "qtap-gateway.qpoint.svc.cluster.local"
+    qpoint.io/egress-port-mapping: "10080:80,10443:443"

--- a/config/webhook/configmap.yaml
+++ b/config/webhook/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: default-pod-annotations-configmap
+  name: gateway-pod-annotations-configmap
   namespace: system
 data:
   annotations.yaml: |
@@ -9,3 +9,18 @@ data:
     qpoint.io/egress-init-tag: "v0.0.7"
     qpoint.io/egress-to-domain: "qtap-gateway.qpoint.svc.cluster.local"
     qpoint.io/egress-port-mapping: "10080:80,10443:443"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: injection-pod-annotations-configmap
+  namespace: system
+data:
+  annotations.yaml: |
+    qpoint.io/inject-ca: "true"
+    qpoint.io/egress-init-tag: "v0.0.7"
+    qpoint.io/qtap-tag: "v0.0.9"
+    qpoint.io/egress-port-mapping: "10080:80,10443:443,10000:"
+    qpoint.io/log-level: "info"
+    qpoint.io/block-unknown: "false"
+    qpoint.io/dns-lookup-family: "V4_ONLY"

--- a/config/webhook/configmap.yaml
+++ b/config/webhook/configmap.yaml
@@ -19,7 +19,7 @@ data:
   annotations.yaml: |
     qpoint.io/inject-ca: "true"
     qpoint.io/egress-init-tag: "v0.0.7"
-    qpoint.io/qtap-tag: "v0.0.9"
+    qpoint.io/qtap-tag: "v0.0.10"
     qpoint.io/egress-port-mapping: "10080:80,10443:443,10000:"
     qpoint.io/log-level: "info"
     qpoint.io/block-unknown: "false"


### PR DESCRIPTION
This pull request introduces sidecar injection of `qtap` as a proxy.  To make use of this new functionality the annotations for a pod will need to be modify during Helm chart installation: https://github.com/qpoint-io/helm-charts/blob/59ac28869297de3450a0fa1dc061b76ef7809248/charts/qtap-operator/values.yaml#L46-L51

The setup is as follows:

- A namespace is labelled or pod annotation set enabling egress.
- The egress labelling will setup the [init container](https://github.com/qpoint-io/kubernetes-qtap-init) which will force routing through the gateway. The default values as seen in  https://github.com/qpoint-io/helm-charts/blob/59ac28869297de3450a0fa1dc061b76ef7809248/charts/qtap-operator/values.yaml#L46-L51 are for routing to a service and so they will need to be overridden with the example found below.
- The namespace requires the `qpoint-injection=enabled` label or the `sidecar.qpoint.io/inject=true`label on the pod.

Once the above is complete the operator will inject both the init container and the sidecar. An example configuration for the pod annotations is as follows:

```
defaultPodAnnotationsConfigmap:
  annotationsYaml: |-
    qpoint.io/inject-ca: "true"
    qpoint.io/egress-init-tag: "v0.0.7"
    qpoint.io/qtap-tag: "v0.0.9"
    qpoint.io/egress-port-mapping: "10080:80,10443:443,10000:"
    qpoint.io/log-level: "info"
    qpoint.io/block-unknown: "false"
    qpoint.io/dns-lookup-family: "V4_ONLY"
```