### PR TITLE
Simplify labels to support service, inject or disable

### DIFF
--- a/api/v1/config.go
+++ b/api/v1/config.go
@@ -18,7 +18,7 @@ type EgressType string
 
 const (
 	EgressType_UNDEFINED EgressType = "undefined"
-	EgressType_DISABLED  EgressType = "disabled"
+	EgressType_DISABLE   EgressType = "disable"
 	EgressType_SERVICE   EgressType = "service"
 	EgressType_INJECT    EgressType = "inject"
 )
@@ -51,8 +51,8 @@ func (c *Config) Init(pod *corev1.Pod) error {
 	configMapName := ""
 
 	switch v := namespace.Labels[NAMESPACE_EGRESS_LABEL]; EgressType(v) {
-	case EgressType_DISABLED:
-		c.EgressType = EgressType_DISABLED
+	case EgressType_DISABLE:
+		c.EgressType = EgressType_DISABLE
 		return nil
 	case EgressType_SERVICE:
 		c.EgressType = EgressType_SERVICE
@@ -69,8 +69,8 @@ func (c *Config) Init(pod *corev1.Pod) error {
 	// order matters as pods override namespaces
 
 	switch v := pod.Labels[POD_EGRESS_LABEL]; EgressType(v) {
-	case EgressType_DISABLED:
-		c.EgressType = EgressType_DISABLED
+	case EgressType_DISABLE:
+		c.EgressType = EgressType_DISABLE
 		return nil
 	case EgressType_SERVICE:
 		c.EgressType = EgressType_SERVICE

--- a/api/v1/config.go
+++ b/api/v1/config.go
@@ -52,11 +52,14 @@ func (c *Config) Init(pod *corev1.Pod) error {
 
 	switch v := namespace.Labels[NAMESPACE_EGRESS_LABEL]; EgressType(v) {
 	case EgressType_DISABLED:
+		c.EgressType = EgressType_DISABLED
 		return nil
 	case EgressType_SERVICE:
+		c.EgressType = EgressType_SERVICE
 		namespaceEgressType = EgressType_SERVICE
 		configMapName = SERVICE_ANNOTATIONS_CONFIGMAP
 	case EgressType_INJECT:
+		c.EgressType = EgressType_INJECT
 		namespaceEgressType = EgressType_INJECT
 		configMapName = INJECT_ANNOTATIONS_CONFIGMAP
 	}
@@ -67,17 +70,21 @@ func (c *Config) Init(pod *corev1.Pod) error {
 
 	switch v := pod.Labels[POD_EGRESS_LABEL]; EgressType(v) {
 	case EgressType_DISABLED:
+		c.EgressType = EgressType_DISABLED
 		return nil
 	case EgressType_SERVICE:
+		c.EgressType = EgressType_SERVICE
 		podEgressType = EgressType_SERVICE
 		configMapName = SERVICE_ANNOTATIONS_CONFIGMAP
 	case EgressType_INJECT:
+		c.EgressType = EgressType_INJECT
 		podEgressType = EgressType_INJECT
 		configMapName = INJECT_ANNOTATIONS_CONFIGMAP
 	}
 
 	// egress is undefined for the entire namespace (regardless of what the pod label says) or pod and thus return immediately
 	if namespaceEgressType == EgressType_UNDEFINED && podEgressType == EgressType_UNDEFINED {
+		c.EgressType = EgressType_UNDEFINED
 		return nil
 	}
 

--- a/api/v1/webhook.go
+++ b/api/v1/webhook.go
@@ -100,6 +100,8 @@ func (w *Webhook) Handle(ctx context.Context, req admission.Request) admission.R
 				return admission.Errored(http.StatusInternalServerError, err)
 			}
 		}
+	case EgressType_DISABLED:
+		webhookLog.Info("Qpoint egress disabled, ignoring...")
 	default:
 		webhookLog.Info("Qpoint egress not enabled, ignoring...")
 	}

--- a/api/v1/webhook.go
+++ b/api/v1/webhook.go
@@ -100,7 +100,7 @@ func (w *Webhook) Handle(ctx context.Context, req admission.Request) admission.R
 				return admission.Errored(http.StatusInternalServerError, err)
 			}
 		}
-	case EgressType_DISABLED:
+	case EgressType_DISABLE:
 		webhookLog.Info("Qpoint egress disabled, ignoring...")
 	default:
 		webhookLog.Info("Qpoint egress not enabled, ignoring...")

--- a/api/v1/webhook.go
+++ b/api/v1/webhook.go
@@ -35,10 +35,9 @@ func (w *Webhook) Handle(ctx context.Context, req admission.Request) admission.R
 
 	// initialize a config with defaults
 	config := &Config{
+		EgressType:        EgressType_UNDEFINED,
 		Namespace:         req.Namespace,
 		OperatorNamespace: w.Namespace,
-		EnabledEgress:     false,
-		EnabledInjection:  false,
 		InjectCa:          false,
 		Client:            w.ApiClient,
 		Ctx:               ctx,
@@ -50,8 +49,11 @@ func (w *Webhook) Handle(ctx context.Context, req admission.Request) admission.R
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
-	if config.EnabledEgress {
-		webhookLog.Info("Qpoint egress enabled, mutating...")
+	switch v := config.EgressType; EgressType(v) {
+	case EgressType_SERVICE:
+		// for this case the pod is mutated for service egress
+
+		webhookLog.Info("Qpoint egress to service enabled, mutating...")
 
 		// mutate the pod to include egress through the gateway
 		if err := MutateEgress(pod, config); err != nil {
@@ -70,21 +72,36 @@ func (w *Webhook) Handle(ctx context.Context, req admission.Request) admission.R
 				return admission.Errored(http.StatusInternalServerError, err)
 			}
 		}
+	case EgressType_INJECT:
+		// for this case the pod is mutated for sidecar egress
 
-	} else {
-		webhookLog.Info("Qpoint egress not enabled, ignoring...")
-	}
+		webhookLog.Info("Qpoint egress to sidecar enabled, mutating...")
 
-	if config.EnabledInjection {
-		webhookLog.Info("Qpoint injection enabled, mutating...")
+		// mutate the pod to include egress through the gateway
+		if err := MutateEgress(pod, config); err != nil {
+			webhookLog.Error(err, "failed to mutate pod for egress")
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
 
 		// mutate the pod to include the sidecar
 		if err := MutateInjection(pod, config); err != nil {
 			webhookLog.Error(err, "failed to mutate pod for injection")
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
-	} else {
-		webhookLog.Info("Qpoint injection not enabled, ignoring...")
+
+		if config.InjectCa {
+			if err := EnsureAssetsInNamespace(config); err != nil {
+				webhookLog.Error(err, "failed to add assets to namespace for ca injection")
+				return admission.Errored(http.StatusInternalServerError, err)
+			}
+
+			if err := MutateCaInjection(pod, config); err != nil {
+				webhookLog.Error(err, "failed to mutate pod for ca injection")
+				return admission.Errored(http.StatusInternalServerError, err)
+			}
+		}
+	default:
+		webhookLog.Info("Qpoint egress not enabled, ignoring...")
 	}
 
 	marshaledPod, err := json.Marshal(pod)

--- a/config/webhook/configmap.yaml
+++ b/config/webhook/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gateway-pod-annotations-configmap
+  name: service-pod-annotations-configmap
   namespace: system
 data:
   annotations.yaml: |
@@ -13,7 +13,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: injection-pod-annotations-configmap
+  name: inject-pod-annotations-configmap
   namespace: system
 data:
   annotations.yaml: |


### PR DESCRIPTION
This simplifies the logic to look for namespace or pod labels which take on different values.

The permitted namespace labels are:

- `qpoint-egress=disable`
- `qpoint-egress=service`
- `qpoint-egress=inject`

The permitted pod labels are:

- `qpoint.io/egress=disable`
- `qpoint.io/egress=service`
- `qpoint.io/egress=inject`