### PR TITLE
Set security context run as user and group from pod annotations

### DIFF
--- a/api/v1/config.go
+++ b/api/v1/config.go
@@ -30,8 +30,7 @@ type Config struct {
 	OperatorNamespace string
 	Client            client.Client
 	Ctx               context.Context
-
-	annotations map[string]string
+	annotations       map[string]string
 }
 
 // Config scenarios:

--- a/config/webhook/configmap.yaml
+++ b/config/webhook/configmap.yaml
@@ -24,3 +24,5 @@ data:
     qpoint.io/log-level: "info"
     qpoint.io/block-unknown: "false"
     qpoint.io/dns-lookup-family: "V4_ONLY"
+    qpoint.io/qtap-uid: "1010"
+    qpoint.io/qtap-gid: "1010"


### PR DESCRIPTION
This is a similar situation as https://github.com/qpoint-io/kubernetes-qtap-operator/pull/12 was done to address. Specifically, there are deployments that set the pod security context  (https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) which overrides the UID and GID of the running container. When this is done the `iptables` `accept` rule created by https://github.com/qpoint-io/kubernetes-qtap-init/ doesn't align and then prevents the sidecar proxy from using the network. This is due to the fact that the the sidecar ends up being configured to route to itself and this breaks registration and pretty much any network connectivity since the sidecar container cannot become healthy.