### PR TITLE
Address CA config map creation race condition

### DIFF
--- a/api/v1/ca.go
+++ b/api/v1/ca.go
@@ -138,13 +138,6 @@ func MutateCaInjection(pod *corev1.Pod, config *Config) error {
 }
 
 func EnsureAssetsInNamespace(config *Config) error {
-	// it is possible that many mutations are requested in succession and this can lead to an "already exists"
-	// for the create operation. Thus, synchronize around the possible creation by only allowing one of this function
-	// to execute at any given time
-	mu := sync.Mutex{}
-	mu.Lock()
-	defer mu.Unlock()
-
 	// the goal is to ensure this exists already or we'll create it
 	qtapCaBundleExists := false
 
@@ -165,6 +158,13 @@ func EnsureAssetsInNamespace(config *Config) error {
 	if qtapCaBundleExists {
 		return nil
 	}
+
+	// it is possible that many mutations are requested in succession and this can lead to an "already exists"
+	// for the create operation. Thus, synchronize around the possible creation by only allowing one of this function
+	// to execute at any given time
+	mu := sync.Mutex{}
+	mu.Lock()
+	defer mu.Unlock()
 
 	// we need to see if we have the qtap ca in the operator namespace
 	qpointRootCaConfigMap := &corev1.ConfigMap{}

--- a/api/v1/ca.go
+++ b/api/v1/ca.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -137,6 +138,13 @@ func MutateCaInjection(pod *corev1.Pod, config *Config) error {
 }
 
 func EnsureAssetsInNamespace(config *Config) error {
+	// it is possible that many mutations are requested in succession and this can lead to an "already exists"
+	// for the create operation. Thus, synchronize around the possible creation by only allowing one of this function
+	// to execute at any given time
+	mu := sync.Mutex{}
+	mu.Lock()
+	defer mu.Unlock()
+
 	// the goal is to ensure this exists already or we'll create it
 	qtapCaBundleExists := false
 


### PR DESCRIPTION
During rapid mutation of pods with the `qpoint.io/inject-ca: "true"` annotation it is possible that a race condition occurs that leads to the following error:

```
2023-12-05T05:18:07Z	ERROR	pod.v1.admission.webhook[2e6e597f-f6b9-435d-a7bf-70f608239668]	failed to add assets to namespace for ca injection	{"error": "creating configmap for Qtap CA bundles: configmaps \"qtap-ca-bundle.crt\" already exists"}
github.com/qpoint-io/kubernetes-qtap-operator/api/v1.(*Webhook).Handle
	/workspace/api/v1/webhook.go:94
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/webhook/admission/webhook.go:169
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/webhook/admission/http.go:98
sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics.InstrumentedHook.InstrumentHandlerInFlight.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/promhttp/instrument_server.go:60
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2136
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/promhttp/instrument_server.go:147
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2136
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2
	/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/promhttp/instrument_server.go:109
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2136
net/http.(*ServeMux).ServeHTTP
	/usr/local/go/src/net/http/server.go:2514
net/http.serverHandler.ServeHTTP
	/usr/local/go/src/net/http/server.go:2938
net/http.(*conn).serve
	/usr/local/go/src/net/http/server.go:2009
```

The issue is that the config map already exists due a a race condition with multiple calls to `EnsureAssetsInNamespace()` and multiple attempts to create the same config map. This pull request locks the write part of the function call so only one can be in-flight at any given time to prevent creation errors.