### PR TITLE
Use qpoint.io/egress as the namespace label

### DIFF
--- a/api/v1/config.go
+++ b/api/v1/config.go
@@ -11,7 +11,7 @@ import (
 
 const SERVICE_ANNOTATIONS_CONFIGMAP = "qtap-operator-service-pod-annotations-configmap"
 const INJECT_ANNOTATIONS_CONFIGMAP = "qtap-operator-inject-pod-annotations-configmap"
-const NAMESPACE_EGRESS_LABEL = "qpoint-egress"
+const NAMESPACE_EGRESS_LABEL = "qpoint.io/egress"
 const POD_EGRESS_LABEL = "qpoint.io/egress"
 
 type EgressType string


### PR DESCRIPTION
We already use `qpoint.io/egress` as the label for pods and this simply makes the label the same for namespaces. The switch is `qpoint-egress` --> `qpoint.io/egress`.