### PR TITLE
Allow for setting security context settings on the init container

### DIFF
--- a/config/webhook/configmap.yaml
+++ b/config/webhook/configmap.yaml
@@ -22,6 +22,10 @@ data:
   annotations.yaml: |
     qpoint.io/inject-ca: "true"
     qpoint.io/qtap-init-tag: "v0.0.8"
+    qpoint.io/qtap-init-run-as-user: "0"
+    qpoint.io/qtap-init-run-as-group: "0"
+    qpoint.io/qtap-init-run-as-non-root: "false"
+    qpoint.io/qtap-init-run-as-privileged: "false"
     qpoint.io/qtap-tag: "v0.0.15"
     qpoint.io/qtap-init-egress-port-mapping: "10080:80,10443:443"
     qpoint.io/qtap-init-egress-accept-uids: "1010"


### PR DESCRIPTION
In secure environments such as OpenShift it is necessary to be able to control the user, group and privilege of the security context of the init container. The init container runs `iptables` and requires elevated permissions to modify the network level routing. This pull request allows for setting the necessary security context settings on the init container so that it can run in these environments.

References:

- https://github.com/linkerd/linkerd2/issues/151
- https://github.com/linkerd/linkerd-inject/pull/7
- https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
- https://kubernetes.io/docs/concepts/security/pod-security-standards/